### PR TITLE
[issue 45] ToggleButton 컴포넌트 구현

### DIFF
--- a/src/components/Button/ToggleButton.jsx
+++ b/src/components/Button/ToggleButton.jsx
@@ -1,0 +1,41 @@
+import { useState } from "react";
+import Button from ".";
+
+// 토글 영역 스타일
+const CONTAINER_STYLE = "w-[236px] md:w-[244px] h-[40px] bg-gray-100 rounded-[6px] flex";
+
+// 토글 상태(on/off) 스타일 - Button 컴포넌트의 "secondary", "outlined" 스타일 사용
+const STATE_SELECT = {
+  on: { variant: "secondary", className: "font-[700] border-[2px]" },
+  off: { variant: "outlined", className: "border-none" },
+};
+
+const getSelectStyle = isSelected => (isSelected ? STATE_SELECT.on : STATE_SELECT.off);
+
+/**
+ * 토글 버튼 컴포넌트
+ *
+ * @param {Object} props
+ * @param {string} [props.className] - 새로 추가할 className
+ * @returns {JSX.Element} 컬러/이미지 중 하나를 선택하는 토글 버튼
+ */
+const ToggleButton = ({ className = "" }) => {
+  const [selectedType, setSelectedType] = useState("color");
+  const colorBtnProps = getSelectStyle(selectedType === "color");
+  const imgBtnProps = getSelectStyle(selectedType === "image");
+
+  const handleBtnClick = type => setSelectedType(type);
+
+  return (
+    <div className={`toggleContainer ${CONTAINER_STYLE} ${className}`}>
+      <Button {...colorBtnProps} onClick={() => handleBtnClick("color")}>
+        컬러
+      </Button>
+      <Button {...imgBtnProps} onClick={() => handleBtnClick("image")}>
+        이미지
+      </Button>
+    </div>
+  );
+};
+
+export default ToggleButton;


### PR DESCRIPTION
## 🔀 PR 내용 요약

ToggleButton 컴포넌트 구현

## ✅ 작업 내용 상세

- [x] 토글 영역, 토글 버튼 스타일 적용
- [x] 반응형 width 적용
- [x] 각 토글 버튼은 기존 버튼 컴포넌트의 스타일 활용(secondary, outlined)
- [x] useState로 토글의 상태 관리
- [x] 버튼 클릭 시 상태 및 스타일 변경

사용 예
```
<ToggleButton />
```

## 📷 스크린샷 (UI 변경 시)

<img width="342" height="151" alt="image" src="https://github.com/user-attachments/assets/7c57e456-2c34-42fc-b197-6e7d8d70be2f" />

## 📌 참고 사항

- [ ] 토글 버튼 작업 중 `Button` 컴포넌트의 일부 스타일을 수정할 필요가 있어, 해당 브랜치에서 스타일을 수정 후 커밋할 예정입니다.
- [ ] Form에서 사용할 때 버튼에 value나 type 속성이 필요할 수 있을 것 같아, 이 부분을 props로 받을지 고민 중입니다.
편하게 의견 공유해주시면, 버튼 컴포넌트들 정리할 때 참고하겠습니다.
