### PR TITLE
[issue 48] ProfileGroup 컴포넌트 분리 구현 (+카드 개수 정보 컴포넌트)

### DIFF
--- a/src/components/ProfileGroup/index.jsx
+++ b/src/components/ProfileGroup/index.jsx
@@ -1,0 +1,23 @@
+// 프로필 이미지 그룹 컴포넌트
+const ProfileGroup = ({ profileImages = [], profileCount = 0 }) => (
+  <div className="flex items-center relative h-7">
+    {profileImages.slice(0, 3).map((img, idx) => (
+      <img
+        key={idx}
+        src={img}
+        alt="profile"
+        className="w-7 h-7 rounded-full border-2 border-white -ml-3 first:ml-0 z-10"
+      />
+    ))}
+    <span className="flex items-center justify-center h-7 rounded-full bg-white text-[#555555] text-xs font-normal absolute z-20 left-[60px] top-0 ml-[-12px] px-2">
+      +{profileCount}
+    </span>
+  </div>
+);
+
+// 카드 개수 정보 컴포넌트
+const CardCountInfo = ({ cardCount }) => (
+  <div className="text-sm text-[#3a3a3a] font-normal">{cardCount}명이 작성했어요!</div>
+);
+
+export { ProfileGroup, CardCountInfo };


### PR DESCRIPTION
## 🔀 PR 내용 요약

Card-List 작업을 하다가 Header와 겹치는 부분을 재사용성을 위해
ProfileGroup 컴포넌트로 분리했습니다.

## ✅ 작업 내용 상세

- profileImages와 profileCount를 받아와 3개는 작은 뱃지?로 표시하고 나머지는 숫자로 표시합니다.
- cardCount를 받아와 숫자 표기

## 📷 스크린샷 (UI 변경 시)

<img width="163" height="69" alt="{7F6FA7FB-056A-4532-96E4-A9C62EAF78D7}" src="https://github.com/user-attachments/assets/ab884fd3-2ad1-47ba-aae3-42fe9ae792ca" />

## 📌 참고 사항

리뷰 시 유의할 점, 남겨둔 TODO 등
