### PR TITLE
[issue 65] Card 컴포넌트 수정

### DIFF
--- a/src/components/Card/index.jsx
+++ b/src/components/Card/index.jsx
@@ -1,89 +1,95 @@
-// import Badge from "./Badge/Badge";
+import { useNavigate } from "react-router-dom";
+import RelationshipBadge from "../Badge/RelationshipBadge";
 import CircleButton from "../Button/CircleButton";
-
-import icDelete from "../../assets/icDelete.svg"; // 휴지통 아이콘 import
-
-// 임시 Badge 컴포넌트
-const Badge = ({ text, badgeColor = "bg-violet-100 text-violet-500" }) => (
-  <span className={`inline-block ${badgeColor} text-xs px-2 py-0.5 rounded-lg mt-0.5`}>{text}</span>
-);
-
-// 임시 Button 컴포넌트 (+버튼)
-const CircleButton = ({ onClick }) => (
-  <button
-    onClick={onClick}
-    className="w-12 h-12 rounded-full border-none bg-gray-500 shadow-sm flex items-center justify-center text-3xl text-white cursor-pointer"
-    aria-label="추가"
-    type="button"
-  >
-    +
-  </button>
-);
+import Button from "../Button";
+import icDelete from "../../assets/icDelete.svg";
 
 /**
  * Card 컴포넌트 props
  * @param {string} imgProfile - 프로필 이미지 URL
  * @param {string} name - 작성자 이름
- * @param {string} badgeText - 뱃지에 표시할 텍스트
- * @param {string} badgeColor - 뱃지 배경 및 텍스트 색상 클래스
+ * @param {string} badgeText - 뱃지에 표시할 텍스트(컬러는 bedge컴포넌트에서 자동연결)
  * @param {string} message - 카드에 표시할 메시지
  * @param {string} date - 작성 날짜
+ * @param {boolean} isDeleteMode - 삭제 버튼 표시 여부
  * @param {function} onDelete - 삭제 버튼 클릭 시 호출되는 함수 (옵션)
  * @param {function} onClick - 카드 클릭 시 호출되는 함수 (옵션)
  * @param {string|number} cardID - 카드 고유 ID (옵션)
  */
 
-// Card 컴포넌트
-const Card = ({ imgProfile, name, badgeText, badgeColor, message = "", date = "", onDelete, onClick, cardID }) => {
+// 삭제 버튼 컴포넌트
+const DeleteButton = ({ onClick }) => (
+  <Button
+    onClick={onClick}
+    className="absolute top-6 right-6 bg-white border border-grayscale-200 flex items-center justify-center w-9 h-9 rounded-lg"
+    aria-label="삭제"
+    type="button"
+    iconOnly
+    variant="outlinedIcon"
+    size={36}
+    width={36}
+  >
+    <img src={icDelete} alt="삭제" />
+  </Button>
+);
+
+// 카드 컴포넌트
+const Card = ({
+  imgProfile,
+  name,
+  badgeText,
+  message = "",
+  date = "",
+  isDeleteMode = false,
+  onDelete,
+  onClick,
+  cardID,
+}) => {
   const handleClickDelete = e => {
     e.stopPropagation();
     onDelete?.(cardID);
   };
 
-  // 삭제 버튼 컴포넌트 조건부 렌더링
-  const DeleteButton = () =>
-    onDelete ? (
-      <button
-        onClick={handleClickDelete}
-        className="absolute top-6 right-6 bg-white border border-gray-200 flex items-center justify-center w-10 h-10 rounded-lg cursor-pointer"
-        aria-label="삭제"
-        type="button"
-      >
-        <img src={icDelete} alt="삭제" className="w-[16px] h-[16px]" />
-      </button>
-    ) : null;
+  //모달 핸들러
+  const handleClickCard = () => {
+    onClick?.(cardID);
+  };
 
   return (
     <div
-      className="bg-white rounded-2xl shadow-sm p-6 card-size flex flex-col gap-4 relative cursor-pointer transition-all"
-      onClick={onClick}
+      className="bg-white rounded-2xl shadow-sm p-6 card-size flex flex-col gap-4 relative cursor-pointer transition-all font-pretendard"
+      onClick={handleClickCard} // 모달 연결
     >
       <div className="flex items-center gap-3">
-        <img src={imgProfile} alt={name} className="w-14 h-14 rounded-full object-cover border border-gray-200" />
+        <img src={imgProfile} alt={name} className="w-14 h-14 rounded-full object-cover border border-grayscale-200" />
         <div>
           <div>
-            <span className="md:text-[20px] text-[18px] font-normal">From.</span>
-            <span className="md:text-[20px] text-[16px] font-bold ml-1">{name}</span>
+            <span className="text-18 md:text-20">From.</span>
+            <span className="text-16 md:text-20 font-bold ml-1">{name}</span>
           </div>
-          <Badge text={badgeText} badgeColor={badgeColor} />
+          <RelationshipBadge relationship={badgeText} />
         </div>
-        <DeleteButton />
+        {isDeleteMode && <DeleteButton onClick={handleClickDelete} />}
       </div>
-      <div className="md:text-[18px] text-[15px] text-gray-700 pt-2 border-t border-gray-200 line-clamp-3">
-        {message}
-      </div>
-      <div className="text-xs text-gray-400 mt-auto">{date}</div>
+      <p className="text-15 md:text-18 text-grayscale-600 pt-2 border-t border-grayscale-200 line-clamp-3">{message}</p>
+      <div className="font-12-regular text-grayscale-400 mt-auto">{date}</div>
     </div>
   );
 };
 
-// +카드 컴포넌트
-const AddCard = ({ onClick }) => {
+// 카드 추가 컴포넌트
+const AddCard = ({ id }) => {
+  const navigate = useNavigate();
+
+  const handleClick = () => {
+    navigate(`/post/${id}/message`);
+  };
+
   return (
     <div className="bg-white rounded-2xl shadow-sm card-size flex items-center justify-center transition-all">
-      <CircleButton onClick={onClick} />
+      <CircleButton onClick={handleClick} />
     </div>
   );
 };
 
-export { Card, Badge, AddCard };
+export { Card, AddCard };

--- a/src/components/Card/index.jsx
+++ b/src/components/Card/index.jsx
@@ -12,16 +12,15 @@ import icDelete from "../../assets/icDelete.svg";
  * @param {string} message - 카드에 표시할 메시지
  * @param {string} date - 작성 날짜
  * @param {boolean} isDeleteMode - 삭제 버튼 표시 여부
- * @param {function} onDelete - 삭제 버튼 클릭 시 호출되는 함수 (옵션)
- * @param {function} onClick - 카드 클릭 시 호출되는 함수 (옵션)
- * @param {string|number} cardID - 카드 고유 ID (옵션)
+ * @param {function} onDelete - 삭제 버튼 클릭 시 호출되는 함수
+ * @param {function} onClick - 카드 클릭 시 호출되는 함수 (모달)
+ * @param {string|number} cardID - 카드 고유 ID
  */
-
 // 삭제 버튼 컴포넌트
 const DeleteButton = ({ onClick }) => (
   <Button
     onClick={onClick}
-    className="absolute top-6 right-6 bg-white border border-grayscale-200 flex items-center justify-center w-9 h-9 rounded-lg"
+    className="absolute top-6 right-6"
     aria-label="삭제"
     type="button"
     iconOnly


### PR DESCRIPTION
## 🔀 PR 내용 요약

card 컴포넌트 수정

## ✅ 작업 내용 상세

- Button 컴포넌트와 연결 (삭제 버튼)
- 모달 핸들러 추가(cardID값을 받아옴)
- AddCard 컴포넌트 구조 변경
- font-family 적용

## 📷 스크린샷 (UI 변경 시)

<img width="824" height="207" alt="{00564683-C18A-4567-8C73-7338053B146F}" src="https://github.com/user-attachments/assets/6581d8ea-3299-46ee-8656-d24958df6021" />

## 📌 참고 사항

- AddCard 클릭시, 카드 만들기 페이지(/post/${id}/message)로 이동이되어 useNavigate적용했습니다.
- 현재 tailwind 반응형 클래스네임이 커스텀클래스에는 적용되지 않아, 유틸 클래스로 폰트 사이즈를 지정해두었습니다.
리뷰 시 유의할 점, 남겨둔 TODO 등
