### PR TITLE
[issue 57] Option 컴포넌트 구현

### DIFF
--- a/src/assets/icEnabled.svg
+++ b/src/assets/icEnabled.svg
@@ -1,0 +1,4 @@
+<svg width="44" height="44" viewBox="0 0 44 44" fill="none" xmlns="http://www.w3.org/2000/svg">
+<rect width="44" height="44" rx="22" fill="#555555"/>
+<path d="M13 22L19.8333 28.0833L30.6667 16" stroke="white" stroke-width="3.33333" stroke-linecap="round"/>
+</svg>

--- a/src/components/Option/ThemeOption.jsx
+++ b/src/components/Option/ThemeOption.jsx
@@ -1,0 +1,95 @@
+import { forwardRef } from "react";
+
+// 테마옵션 컴포넌트에 쓰이는 컬러/이미지 별 스타일이 조금 달라서
+// optionType="color/image"으로 제어해 THEME_OPTION_STYLES 안에서 함께 관리합니다.
+const THEME_OPTION_STYLES = {
+  label:
+    "theme-option relative w-full flex items-center justify-center aspect-square rounded-[16px] cursor-pointer overflow-hidden",
+  input: "theme-option__input appearance-none w-0 h-0 block",
+  check:
+    "theme-option__check after:content-[''] block relative after:bg-[url('./assets/icEnabled.svg')] after:w-[44px] after:h-[44px] after:z-5",
+  color: "border border-black/10",
+  image: "bg-no-repeat bg-center bg-cover",
+  imageOverlay:
+    "before:content-[''] before:absolute before:inset-0 before:bg-white/70 before:rounded-[16px] before:pointer-events-none before:z-1",
+};
+
+// api 명세에 hex?컬러 데이터가 없는 것 같은데 어떻게 처리하면 좋을까요.(제가 놓친 것일 수도..)
+// 로직 자체가 이렇게 굴러가면 안되는 것일까요..
+const COLOR = {
+  beige: "#FFE2AD",
+  purple: "#ECD9FF",
+  blue: "#B1E4FF",
+  green: "#D0F5C3",
+};
+
+const ThemeOption = forwardRef(
+  ({ optionType = "color", value, name, label, checked = false, onChange, className = "" }, ref) => {
+    const handleChange = () => {
+      onChange?.(value);
+    };
+
+    // 라벨 태그에 aria-label 텍스트 생성
+    let ariaLabel = "";
+    if (optionType === "color") {
+      ariaLabel = `배경 색상 ${label || value}${checked ? " 선택됨" : ""}`;
+    } else if (optionType === "image") {
+      ariaLabel = `배경 이미지${checked ? " 선택됨" : ""}`;
+    }
+
+    // bg 이미지는 label에 인라인 background 스타일 적용하고(이미지가 1:1 비율이 아닐때를 고려해 bg-cover 속성으로 처리하기 위함...),
+    // 대신 label에 aria 속성을 지정해주는게 어떤지 생각해봤습니다. (이미지/컬러 모두 대응)
+
+    let labelStyle = {};
+    if (optionType === "image") {
+      labelStyle = { backgroundImage: `url(${value})` };
+    } else if (optionType === "color") {
+      labelStyle = { backgroundColor: COLOR[value] || value };
+    }
+
+    const typeClass =
+      optionType === "color" ? THEME_OPTION_STYLES.color : optionType === "image" ? THEME_OPTION_STYLES.image : "";
+
+    // 테마 옵션 이미지 타입의 checked일 때만 오버레이 스타일 추가
+    const overlayClass = optionType === "image" && checked ? THEME_OPTION_STYLES.imageOverlay : "";
+
+    return (
+      <label
+        className={[
+          THEME_OPTION_STYLES.label,
+          typeClass,
+          checked ? THEME_OPTION_STYLES.check : "",
+          overlayClass,
+          className,
+        ]
+          .filter(Boolean)
+          .join(" ")}
+        aria-label={ariaLabel}
+        style={labelStyle}
+      >
+        <input
+          ref={ref}
+          type="radio"
+          name={name}
+          value={value}
+          checked={checked}
+          onChange={handleChange}
+          className={THEME_OPTION_STYLES.input}
+          aria-checked={checked}
+        />
+      </label>
+    );
+  },
+);
+
+const ThemeOptionGroup = ({ children, className = "", ...props }) => (
+  <div
+    className={["theme-options grid grid-cols-2 md:grid-cols-4 gap-[12px] md:gap-[16px]", className]
+      .filter(Boolean)
+      .join(" ")}
+    {...props}
+  >
+    {children}
+  </div>
+);
+export { ThemeOption, ThemeOptionGroup };


### PR DESCRIPTION
## 🔀 PR 내용 요약
> 롤링페이퍼 보내기 페이지에서 사용되는 배경 테마(컬러/이미지) 옵션 컴포넌트 구현

## ✅ 작업 내용 상세
* 각 옵션은 실제 라디오 버튼(`input[type="radio"]`)을 사용하고, label 클릭 시 선택값이 변경되도록 구현
* props 제어, aria-label(접근성) 구조
* optionType(컬러/이미지)에 따라 스타일 및 동작 분리
* 체크 선택 기능 구현

### 테스트 코드
App.jsx
```jsx
import { useState } from "react";
import { ThemeOption, ThemeOptionGroup } from "./components/Option/ThemeOption";
import "./App.css";

function App() {
  // 테스트용 컬러/이미지 데이터
  const COLOR_OPTIONS = ["beige", "purple", "blue", "green"];
  const IMAGE_OPTIONS = [
    "https://picsum.photos/id/683/3840/2160",
    "https://picsum.photos/id/24/3840/2160",
    "https://picsum.photos/id/599/3840/2160",
    "https://picsum.photos/id/1058/3840/2160",
  ];

  const [selectedColor, setSelectedColor] = useState(COLOR_OPTIONS[0]);
  const [selectedImage, setSelectedImage] = useState(IMAGE_OPTIONS[0]);

  return (
    <div>
      <ThemeOptionGroup>
        {COLOR_OPTIONS.map(color => (
          <ThemeOption
            key={color}
            optionType="color"
            value={color}
            label={color}
            checked={selectedColor === color}
            onChange={setSelectedColor}
            name="theme-color"
          />
        ))}
      </ThemeOptionGroup>
      <ThemeOptionGroup>
        {IMAGE_OPTIONS.map(url => (
          <ThemeOption
            key={url}
            optionType="image"
            value={url}
            checked={selectedImage === url}
            onChange={setSelectedImage}
            name="theme-image"
          />
        ))}
      </ThemeOptionGroup>
    </div>
  );
}

export default App;
```

## 📷 스크린샷 (UI 변경 시)
>  배경 옵션 이미지는 label에 인라인 background 스타일 적용함.
(PC 첨부 사진처럼 배경 이미지가 1:1 비율이 아닐때를 고려해 bg-cover 속성으로 처리하기 위함)

|PC|Mobile|
|---|---|
|<img width="1666" height="915" alt="스크린샷 2025-08-20 오전 11 36 11" src="https://github.com/user-attachments/assets/14b66c47-9893-46e1-acc3-c3c51f5c0716" />|<img width="369" height="790" alt="스크린샷 2025-08-20 오후 12 11 19" src="https://github.com/user-attachments/assets/1176bc99-6ba1-4412-addd-e8ba0af2a0ac" />|

> **대신 label에 aria 속성을 지정해주는게 어떤지**(e.g. aria-label:"배경 테마 blue 선택") 생각해보고 일단 그렇게 만들어 두었습니다. 
(이미지/컬러 모두 대응)

|aria-label 으로 대체|
|---|
|<img width="1913" height="759" alt="스크린샷 2025-08-20 오전 9 56 39" src="https://github.com/user-attachments/assets/5e23ab3b-ecf6-4f32-a061-4d122f7f7284" />|


## 📌 참고 사항
- 위에 명시된 기능 구현(UI, 선택 체크) 까지만 작업된 상태
- API 명세 고려한 후속 작업은 해당 페이지 작업자가 이어서 개발
