### PR TITLE
[issue 78] usePageTitle 훅 타이틀 포맷 리팩토링

### DIFF
--- a/src/hooks/usePageTitle.js
+++ b/src/hooks/usePageTitle.js
@@ -2,15 +2,11 @@ import { useEffect } from "react";
 
 /**
  * 페이지 타이틀 설정 훅
- * @param {string} [title] - 페이지 타이틀 (기본값은 Rolling)
+ * @param {string} [title=""] - 페이지 타이틀 (기본값은 Rolling)
  */
-const usePageTitle = title => {
+const usePageTitle = (title = "") => {
   useEffect(() => {
-    if (title) {
-      document.title = `Rolling | ${title}`;
-    } else {
-      document.title = "Rolling";
-    }
+    document.title = `${title && title + " | "}Rolling`;
   }, [title]);
 };
 

--- a/src/pages/Page.jsx
+++ b/src/pages/Page.jsx
@@ -1,0 +1,11 @@
+import usePageTitle from "../hooks/usePageTitle";
+
+/**
+ * 페이지 타이틀 설정 컴포넌트
+ */
+const Page = ({ title = "", children }) => {
+  usePageTitle(title);
+  return <>{children}</>;
+};
+
+export default Page;

--- a/src/pages/Page/index.jsx
+++ b/src/pages/Page/index.jsx
@@ -1,4 +1,4 @@
-import usePageTitle from "../hooks/usePageTitle";
+import usePageTitle from "../../hooks/usePageTitle";
 
 /**
  * 페이지 타이틀 설정 컴포넌트


### PR DESCRIPTION
## 🔀 PR 내용 요약
> usePageTitle 훅 타이틀 포맷 간결하게 개선

## ✅ 작업 내용 상세
* title의 기본 값을 공백으로 두고, 값이 지정되면 이어붙이는 방식으로 개선
* 서브 페이지 명이 앞으로 가도록 순서 개선
```
인기 · 최신 롤링 페이퍼 | Rolling
롤링페이퍼 목록 | Rolling
롤링페이퍼 만들기 | Rolling
```

## 📷 스크린샷 (UI 변경 시)

## 📌 참고 사항
