### PR TITLE
[issue 71] 롤링 페이퍼 만들기 페이지 구현

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -120,6 +120,9 @@
   .my-container {
     @apply mx-auto max-w-[1248px] px-[24px];
   }
+  .form-container {
+    @apply mt-[122px] max-w-[320px] md:max-w-[720px] mx-auto;
+  }
   .card-size {
     @apply min-w-[320px] min-h-[230px] sm:w-[70vw] sm:min-h-[250px] md:w-[384px] md:min-h-[280px];
   }

--- a/src/api/postRecipients/index.js
+++ b/src/api/postRecipients/index.js
@@ -1,0 +1,12 @@
+import instance from "../instance";
+
+const postRecipients = async ({ name, backgroundColor = "beige" } = {}) => {
+  try {
+    const { data } = await instance.post(`recipients/`, { name, backgroundColor });
+    return data;
+  } catch (error) {
+    console.error(error);
+  }
+};
+
+export default postRecipients;

--- a/src/api/postRecipients/index.js
+++ b/src/api/postRecipients/index.js
@@ -1,8 +1,8 @@
 import instance from "../instance";
 
-const postRecipients = async ({ name, backgroundColor = "beige" } = {}) => {
+const postRecipients = async ({ name, backgroundColor = "beige", backgroundImageURL } = {}) => {
   try {
-    const { data } = await instance.post(`recipients/`, { name, backgroundColor });
+    const { data } = await instance.post(`recipients/`, { name, backgroundColor, backgroundImageURL });
     return data;
   } catch (error) {
     console.error(error);

--- a/src/components/Button/ToggleButton/index.jsx
+++ b/src/components/Button/ToggleButton/index.jsx
@@ -14,9 +14,14 @@ import RegularButton from "../RegularButton";
  *
  * @returns {JSX.Element} 컬러/이미지 중 하나를 선택하는 토글 버튼
  */
-const ToggleButton = ({ className = "", toggleProps = {}, colorBtnProps = {}, imageBtnProps = {} }) => {
-  const [selectedType, setSelectedType] = useState("color");
-
+const ToggleButton = ({
+  selectedType,
+  setSelectedType,
+  className = "",
+  toggleProps = {},
+  colorBtnProps = {},
+  imageBtnProps = {},
+}) => {
   const commonBtnStyle = COMMON_BUTTON;
   const toggleBtnStyle = TOGGLE_CONTAINER;
   const colorBtnStyle = getSelectStyle(selectedType === "color");

--- a/src/constants/OPTIONS.js
+++ b/src/constants/OPTIONS.js
@@ -1,0 +1,9 @@
+const COLOR_OPTIONS = ["beige", "purple", "blue", "green"];
+const IMAGE_OPTIONS = [
+  "https://picsum.photos/id/683/3840/2160",
+  "https://picsum.photos/id/24/3840/2160",
+  "https://picsum.photos/id/599/3840/2160",
+  "https://picsum.photos/id/1058/3840/2160",
+];
+
+export { COLOR_OPTIONS, IMAGE_OPTIONS };

--- a/src/pages/PostPage/index.jsx
+++ b/src/pages/PostPage/index.jsx
@@ -1,31 +1,35 @@
 import { Input } from "@headlessui/react";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import ToggleButton from "../../components/Button/ToggleButton";
 import { ThemeOption, ThemeOptionGroup } from "../../components/Option/ThemeOption";
 import { COLOR_OPTIONS, IMAGE_OPTIONS } from "../../constants/OPTIONS";
 import RegularButton from "../../components/Button/RegularButton";
 
 const PostPage = () => {
-  const [formData, setFormData] = useState({
-    name: "",
-    backgroundColor: COLOR_OPTIONS[0],
-    backgroundImageURL: IMAGE_OPTIONS[0],
-  });
+  const [name, setName] = useState("");
+  const [backgroundColor, setBackgroundColor] = useState(COLOR_OPTIONS[0]);
+  const [backgroundImageURL, setBackgroundImageURL] = useState(IMAGE_OPTIONS[0]);
+
   const [selectedType, setSelectedType] = useState("color");
 
   const isRenderColor = selectedType === "color" ? true : false;
 
+  useEffect(() => {
+    // selectedType : color 면 img 안보내기
+    // selectedType : image 면 color, img 다보내기
+  }, []);
+
   return (
     <form className="form-container flex flex-col gap-[50px]">
       <div className="flex flex-col gap-[12px]">
-        <h3 className="text-gray-900 font-24-bold">To.</h3>
+        <h3 className="text-gray-900 font-24-bold">To. {name}</h3>
         <Input
-          placeholder="ddd"
+          placeholder="받는 사람 이름을 입력해 주세요"
           type="text"
           className={"border border-gray-300 rounded-[8px] h-[50px] px-[16px] py-[12px] font-16-regular text-gray-500"}
-          onChange
-          value
-          errorMsg
+          onChange={e => setName(e.target.value)}
+          value={name}
+          errorMsg={"테스트"}
         />
       </div>
 
@@ -49,8 +53,8 @@ const PostPage = () => {
                 label={color}
                 name="theme-color"
                 value={color}
-                checked={formData.backgroundColor === color}
-                onChange={() => setFormData(prev => ({ ...prev, backgroundColor: color }))}
+                checked={backgroundColor === color}
+                onChange={setBackgroundColor}
               />
             ))
           : IMAGE_OPTIONS.map(url => (
@@ -59,8 +63,8 @@ const PostPage = () => {
                 optionType="image"
                 name="theme-image"
                 value={url}
-                checked={formData.backgroundImageURL === url}
-                onChange={() => setFormData(prev => ({ ...prev, backgroundImageURL: url }))}
+                checked={backgroundImageURL === url}
+                onChange={setBackgroundImageURL}
               />
             ))}
       </ThemeOptionGroup>

--- a/src/pages/PostPage/index.jsx
+++ b/src/pages/PostPage/index.jsx
@@ -4,23 +4,47 @@ import ToggleButton from "../../components/Button/ToggleButton";
 import { ThemeOption, ThemeOptionGroup } from "../../components/Option/ThemeOption";
 import { COLOR_OPTIONS, IMAGE_OPTIONS } from "../../constants/OPTIONS";
 import RegularButton from "../../components/Button/RegularButton";
+import postRecipients from "../../api/postRecipients";
+import { useNavigate } from "react-router";
 
 const PostPage = () => {
   const [name, setName] = useState("");
   const [backgroundColor, setBackgroundColor] = useState(COLOR_OPTIONS[0]);
   const [backgroundImageURL, setBackgroundImageURL] = useState(IMAGE_OPTIONS[0]);
-
   const [selectedType, setSelectedType] = useState("color");
-
   const isRenderColor = selectedType === "color" ? true : false;
 
-  useEffect(() => {
-    // selectedType : color 면 img 안보내기
-    // selectedType : image 면 color, img 다보내기
-  }, []);
+  const navigate = useNavigate();
+
+  const getResponse = async () => {
+    switch (selectedType) {
+      case "color":
+        return await postRecipients({ name, backgroundColor });
+
+      case "image":
+        return await postRecipients({ name, backgroundColor, backgroundImageURL });
+
+      default:
+        return null;
+    }
+  };
+
+  const handleSubmitRecipient = async e => {
+    e.preventDefault();
+    try {
+      if (!name) {
+        throw new Error("받는 사람 이름을 입력해주세요.");
+      }
+      const response = await getResponse();
+      const { id } = response;
+      navigate(`/post/${id}`);
+    } catch (error) {
+      console.log(error.message);
+    }
+  };
 
   return (
-    <form className="form-container flex flex-col gap-[50px]">
+    <form onSubmit={handleSubmitRecipient} className="form-container flex flex-col gap-[50px]">
       <div className="flex flex-col gap-[12px]">
         <h3 className="text-gray-900 font-24-bold">To. {name}</h3>
         <Input

--- a/src/pages/PostPage/index.jsx
+++ b/src/pages/PostPage/index.jsx
@@ -1,4 +1,3 @@
-import { Input } from "@headlessui/react";
 import { useEffect, useState } from "react";
 import ToggleButton from "../../components/Button/ToggleButton";
 import { ThemeOption, ThemeOptionGroup } from "../../components/Option/ThemeOption";
@@ -6,12 +5,17 @@ import { COLOR_OPTIONS, IMAGE_OPTIONS } from "../../constants/OPTIONS";
 import RegularButton from "../../components/Button/RegularButton";
 import postRecipients from "../../api/postRecipients";
 import { useNavigate } from "react-router";
-
+import Input from "../../components/Form/Input";
+import useToast from "../../hooks/useToast";
 const PostPage = () => {
   const [name, setName] = useState("");
   const [backgroundColor, setBackgroundColor] = useState(COLOR_OPTIONS[0]);
   const [backgroundImageURL, setBackgroundImageURL] = useState(IMAGE_OPTIONS[0]);
   const [selectedType, setSelectedType] = useState("color");
+  const [errorMsg, setErrorMsg] = useState("");
+
+  const { createToast } = useToast();
+
   const isRenderColor = selectedType === "color" ? true : false;
 
   const navigate = useNavigate();
@@ -33,16 +37,23 @@ const PostPage = () => {
     e.preventDefault();
     try {
       if (!name) {
-        throw new Error("받는 사람 이름을 입력해주세요.");
+        throw new Error("값을 입력해주세요.");
       }
       const response = await getResponse();
       const { id } = response;
       navigate(`/post/${id}`);
     } catch (error) {
-      console.log(error.message);
+      createToast({ message: error.message, type: "error", bottom: 40, duration: 5000 });
     }
   };
 
+  const handleBlur = () => {
+    if (!name) {
+      setErrorMsg("값을 입력해주세요.");
+    } else {
+      setErrorMsg("");
+    }
+  };
   return (
     <form onSubmit={handleSubmitRecipient} className="form-container flex flex-col gap-[50px]">
       <div className="flex flex-col gap-[12px]">
@@ -50,10 +61,10 @@ const PostPage = () => {
         <Input
           placeholder="받는 사람 이름을 입력해 주세요"
           type="text"
-          className={"border border-gray-300 rounded-[8px] h-[50px] px-[16px] py-[12px] font-16-regular text-gray-500"}
           onChange={e => setName(e.target.value)}
           value={name}
-          errorMsg={"테스트"}
+          onBlur={handleBlur}
+          errorMsg={errorMsg}
         />
       </div>
 

--- a/src/pages/PostPage/index.jsx
+++ b/src/pages/PostPage/index.jsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useState } from "react";
 import ToggleButton from "../../components/Button/ToggleButton";
 import { ThemeOption, ThemeOptionGroup } from "../../components/Option/ThemeOption";
 import { COLOR_OPTIONS, IMAGE_OPTIONS } from "../../constants/OPTIONS";
@@ -6,15 +6,12 @@ import RegularButton from "../../components/Button/RegularButton";
 import postRecipients from "../../api/postRecipients";
 import { useNavigate } from "react-router";
 import Input from "../../components/Form/Input";
-import useToast from "../../hooks/useToast";
 const PostPage = () => {
   const [name, setName] = useState("");
   const [backgroundColor, setBackgroundColor] = useState(COLOR_OPTIONS[0]);
   const [backgroundImageURL, setBackgroundImageURL] = useState(IMAGE_OPTIONS[0]);
   const [selectedType, setSelectedType] = useState("color");
   const [errorMsg, setErrorMsg] = useState("");
-
-  const { createToast } = useToast();
 
   const isRenderColor = selectedType === "color" ? true : false;
 
@@ -35,16 +32,9 @@ const PostPage = () => {
 
   const handleSubmitRecipient = async e => {
     e.preventDefault();
-    try {
-      if (!name) {
-        throw new Error("값을 입력해주세요.");
-      }
-      const response = await getResponse();
-      const { id } = response;
-      navigate(`/post/${id}`);
-    } catch (error) {
-      createToast({ message: error.message, type: "error", bottom: 40, duration: 5000 });
-    }
+    const response = await getResponse();
+    const { id } = response;
+    navigate(`/post/${id}`);
   };
 
   const handleBlur = () => {
@@ -103,7 +93,7 @@ const PostPage = () => {
               />
             ))}
       </ThemeOptionGroup>
-      <RegularButton size={56} width="w-full" type="submit">
+      <RegularButton size={56} width="w-full" type="submit" disabled={!name}>
         생성하기
       </RegularButton>
     </form>

--- a/src/pages/PostPage/index.jsx
+++ b/src/pages/PostPage/index.jsx
@@ -6,7 +6,15 @@ import { COLOR_OPTIONS, IMAGE_OPTIONS } from "../../constants/OPTIONS";
 import RegularButton from "../../components/Button/RegularButton";
 
 const PostPage = () => {
-  const [formData, setFormData] = useState({ name: "", backgroundColor: "beige", backgroundImageURL: "" });
+  const [formData, setFormData] = useState({
+    name: "",
+    backgroundColor: COLOR_OPTIONS[0],
+    backgroundImageURL: IMAGE_OPTIONS[0],
+  });
+  const [selectedType, setSelectedType] = useState("color");
+
+  const isRenderColor = selectedType === "color" ? true : false;
+
   return (
     <form className="form-container flex flex-col gap-[50px]">
       <div className="flex flex-col gap-[12px]">
@@ -26,19 +34,35 @@ const PostPage = () => {
         <p className="text-gray-500 font-16-regular">컬러를 선택하거나, 이미지를 선택할 수 있습니다.</p>
       </div>
 
-      <ToggleButton colorBtnProps={{ type: "button" }} imageBtnProps={{ type: "button" }} />
+      <ToggleButton
+        selectedType={selectedType}
+        setSelectedType={setSelectedType}
+        colorBtnProps={{ type: "button" }}
+        imageBtnProps={{ type: "button" }}
+      />
       <ThemeOptionGroup>
-        {COLOR_OPTIONS.map(color => (
-          <ThemeOption
-            key={color}
-            optionType="color"
-            label={color}
-            name="theme-color"
-            value={color}
-            checked={formData.backgroundColor === color}
-            onChange={() => setFormData(prev => ({ ...prev, backgroundColor: color }))}
-          />
-        ))}
+        {isRenderColor
+          ? COLOR_OPTIONS.map(color => (
+              <ThemeOption
+                key={color}
+                optionType="color"
+                label={color}
+                name="theme-color"
+                value={color}
+                checked={formData.backgroundColor === color}
+                onChange={() => setFormData(prev => ({ ...prev, backgroundColor: color }))}
+              />
+            ))
+          : IMAGE_OPTIONS.map(url => (
+              <ThemeOption
+                key={url}
+                optionType="image"
+                name="theme-image"
+                value={url}
+                checked={formData.backgroundImageURL === url}
+                onChange={() => setFormData(prev => ({ ...prev, backgroundImageURL: url }))}
+              />
+            ))}
       </ThemeOptionGroup>
       <RegularButton size={56} width="w-full" type="submit">
         생성하기

--- a/src/pages/PostPage/index.jsx
+++ b/src/pages/PostPage/index.jsx
@@ -1,11 +1,49 @@
 import { Input } from "@headlessui/react";
+import { useState } from "react";
+import ToggleButton from "../../components/Button/ToggleButton";
+import { ThemeOption, ThemeOptionGroup } from "../../components/Option/ThemeOption";
+import { COLOR_OPTIONS, IMAGE_OPTIONS } from "../../constants/OPTIONS";
+import RegularButton from "../../components/Button/RegularButton";
 
 const PostPage = () => {
+  const [formData, setFormData] = useState({ name: "", backgroundColor: "beige", backgroundImageURL: "" });
   return (
-    <div>
-      To.
-      <Input placeholder="ddd" />
-    </div>
+    <form className="form-container flex flex-col gap-[50px]">
+      <div className="flex flex-col gap-[12px]">
+        <h3 className="text-gray-900 font-24-bold">To.</h3>
+        <Input
+          placeholder="ddd"
+          type="text"
+          className={"border border-gray-300 rounded-[8px] h-[50px] px-[16px] py-[12px] font-16-regular text-gray-500"}
+          onChange
+          value
+          errorMsg
+        />
+      </div>
+
+      <div className="flex flex-col gap-[4px]">
+        <h3 className="text-gray-900 font-24-bold">배경화면을 선택해 주세요.</h3>
+        <p className="text-gray-500 font-16-regular">컬러를 선택하거나, 이미지를 선택할 수 있습니다.</p>
+      </div>
+
+      <ToggleButton colorBtnProps={{ type: "button" }} imageBtnProps={{ type: "button" }} />
+      <ThemeOptionGroup>
+        {COLOR_OPTIONS.map(color => (
+          <ThemeOption
+            key={color}
+            optionType="color"
+            label={color}
+            name="theme-color"
+            value={color}
+            checked={formData.backgroundColor === color}
+            onChange={() => setFormData(prev => ({ ...prev, backgroundColor: color }))}
+          />
+        ))}
+      </ThemeOptionGroup>
+      <RegularButton size={56} width="w-full" type="submit">
+        생성하기
+      </RegularButton>
+    </form>
   );
 };
 


### PR DESCRIPTION
## 🔀 PR 내용 요약
> 롤링페이퍼 만들기 페이지 구현 및 테스트 완료

## ✅ 작업 내용 상세
- [x] 이름 입력시 To. 옆에 이름이 뜨도록 구현했습니다.
- [x] getResponse : API 명세서에 맞게 color type일 때는 이미지를 보내지 않고, image type 일 때는 모두 보내도록 구현했습니다.
- [x] 이름을 입력하지 않고 생성하기 버튼을 클릭할 시. 토스트 메시지가 뜨는 기능을 추가했습니다.
- [x] input에 값을 입력하지 않고 focusout 시 바로 아래에 에러메시지가 뜨도록 구현했습니다. 
- [x] 반응형 디자인을 구현했습니다.

## 📷 스크린샷 (UI 변경 시)
<img width="2106" height="1508" alt="localhost_5173_post_" src="https://github.com/user-attachments/assets/839246a1-7592-423e-a4a0-96c92e86ab7c" />
<img width="2106" height="1508" alt="localhost_5173_post_ (1)" src="https://github.com/user-attachments/assets/7bf000ee-2609-4cbe-b235-a0f314bf8f8c" />
<img width="2106" height="1544" alt="localhost_5173_post_ (2)" src="https://github.com/user-attachments/assets/ff73f8b8-62a9-4ed6-a88d-914568b28a41" />
<img width="2106" height="1544" alt="localhost_5173_post_ (3)" src="https://github.com/user-attachments/assets/6edf6824-9779-4228-9190-6d28d7e48537" />
<img width="2106" height="1508" alt="image" src="https://github.com/user-attachments/assets/d0c786e4-4603-41c3-98cf-ef2d18fc1bb5" />
<img width="360" height="1800" alt="localhost_5173_post_ (5)" src="https://github.com/user-attachments/assets/e862398f-74d4-49b6-b6bd-52ee7dcb1fb9" />



## 📌 참고 사항


리뷰 시 유의할 점, 남겨둔 TODO 등
